### PR TITLE
Make github know it is a swift not a c repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+Hekate/Hekate/OpenSSL/include-ios/* linguist-vendored
+Hekate/Hekate/OpenSSL/include-macos/* linguist-vendored


### PR DESCRIPTION
Add .gitattributes informing github linguist about openssl dependency.
As described here https://github.com/github/linguist#overrides
