### PR TITLE
Return receiptData and device ID data upon validation

### DIFF
--- a/Hekate/Hekate Demo iOS/HekateDemoViewModel.swift
+++ b/Hekate/Hekate Demo iOS/HekateDemoViewModel.swift
@@ -33,9 +33,9 @@ struct HekateDemoViewModel {
         guard let result = self.lastValidationResult else { return "(No result)" }
 
         switch result {
-        case .success(let receipt):
+        case .success(let receipt, _, _):
             return "Valid\n" + receipt.description
-        case .error(let error):
+        case .error(let error, _, _):
             return "Invalid: \(error)"
         }
     }


### PR DESCRIPTION
Result type is extended to allow for
- optional receiptData
- optional device ID Data
This data might be needed by the client in addition to the validated parsed receipt struct.