### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ script:
   - xcodebuild -version
   - xcodebuild -showsdks
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: objective-c
+osx_image: xcode9.2
+
+env:
+  global:
+  - LC_CTYPE=en_US.UTF-8
+  - LANG=en_US.UTF-8
+  - PROJECT=AppReceiptValidator/AppReceiptValidator.xcodeproj
+
+matrix:
+    - DESTINATION="OS=11.2,name=iPhone X"          SCHEME="AppReceiptValidator Demo iOS"
+    - DESTINATION="arch=x86_64"                    SCHEME="AppReceiptValidator Demo macOS"
+
+script:
+  - set -o pipefail
+  - xcodebuild -version
+  - xcodebuild -showsdks
+  - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
   - xcodebuild -version
   - xcodebuild -showsdks
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty;
+

--- a/README.md
+++ b/README.md
@@ -197,4 +197,3 @@ Anybody want to automate this?
 
 ## Credits
 AppReceiptValidator is brought to you by [IdeasOnCanvas GmbH](https://ideasoncanvas.com), the creator of [MindNode for iOS, macOS & watchOS](https://mindnode.com).
-

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Platforms iOS, macOS](https://img.shields.io/badge/Platform-iOS%20|%20macOS-blue.svg "Platforms iOS, macOS")
 ![Language Swift](https://img.shields.io/badge/Language-Swift%204-orange.svg "Language")
 [![License Apache 2.0 + OpenSSL](https://img.shields.io/badge/License-Apache%202.0%20|%20OpenSSL%20-aaaaff.svg "License")](LICENSE)
+[![Build Status](https://travis-ci.org/IdeasOnCanvas/AppReceiptValidator.svg?branch=master)](https://travis-ci.org/IdeasOnCanvas/AppReceiptValidator)
 [![Twitter: @hannesoid](https://img.shields.io/badge/Twitter-@hannesoid-red.svg?style=flat)](https://twitter.com/hannesoid)
 
 


### PR DESCRIPTION
Fixes #40

Configured to runs demo app's macOS and iOS tests. This should guarantee:
- framework targets are built
- tests are run
- demo apps can be built

# Reviewer
- travis probably still needs to be enabled for this repo, @aquarius ?