### PR TITLE
Support App extensions

### DIFF
--- a/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
+++ b/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
@@ -1733,6 +1733,7 @@
 		D1D6F4BB1F5D684C00E86FE1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -1764,6 +1765,7 @@
 		D1D6F4BC1F5D684C00E86FE1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -1794,6 +1796,7 @@
 		D1D6F4C81F5D687400E86FE1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1825,6 +1828,7 @@
 		D1D6F4C91F5D687400E86FE1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;


### PR DESCRIPTION
Declares support for Application Extensions in iOS & macOS by setting `APPLICATION_EXTENSION_API_ONLY = YES;`
