### PR TITLE
Fix quantity and webOrderLineItemID parsing, update for Xcode 10.2, improve convenience

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.2
 
 env:
   global:
@@ -7,7 +7,7 @@ env:
     - LANG=en_US.UTF-8
     - PROJECT=AppReceiptValidator/AppReceiptValidator.xcodeproj
   matrix:
-    - DESTINATION="OS=12.0,name=iPhone X"          SCHEME="AppReceiptValidator Demo iOS"
+    - DESTINATION="OS=12.2,name=iPhone X"          SCHEME="AppReceiptValidator Demo iOS"
     - DESTINATION="arch=x86_64"                    SCHEME="AppReceiptValidator Demo macOS"
 
 script:

--- a/AppReceiptValidator/AppReceiptValidator Demo iOS/ViewController.swift
+++ b/AppReceiptValidator/AppReceiptValidator Demo iOS/ViewController.swift
@@ -9,9 +9,8 @@
 import AppReceiptValidator
 import UIKit
 
-
-// MARK: - ViewController
-
+/// Displays two textfields. One to paste a receipt into as base64 string, the other displaying the parsed receipt.
+/// A device identifier for validation is not supported, have a look at the mac demo instead.
 class ViewController: UIViewController, UITextViewDelegate {
 
     @IBOutlet private var inputTextView: UITextView!

--- a/AppReceiptValidator/AppReceiptValidator Demo macOS/ViewController.swift
+++ b/AppReceiptValidator/AppReceiptValidator Demo macOS/ViewController.swift
@@ -9,9 +9,8 @@
 import AppReceiptValidator
 import Cocoa
 
-
-// MARK: - ViewController
-
+/// Displays two textfields. One to paste a receipt into as base64 string, the other displaying the parsed receipt.
+/// A device identifier can be added in a third field, which is then used to validate the receipt.
 class ViewController: NSViewController, NSTextViewDelegate, NSTextFieldDelegate {
 
     private var textFieldObserver: Any?

--- a/AppReceiptValidator/AppReceiptValidator Demo macOS/ViewController.swift
+++ b/AppReceiptValidator/AppReceiptValidator Demo macOS/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: NSViewController, NSTextViewDelegate, NSTextFieldDelegate 
         self.dropReceivingView.handleDroppedFile = { [unowned self] url in
             self.update(url: url)
         }
-        self.textFieldObserver = NotificationCenter.default.addObserver(forName: NSTextField.textDidChangeNotification, object: self.identifierTextField, queue: .main) { [weak self] notification in
+        self.textFieldObserver = NotificationCenter.default.addObserver(forName: NSTextField.textDidChangeNotification, object: self.identifierTextField, queue: .main) { [weak self] _ in
             guard let self = self else { return }
 
             self.identifierDidChange(self.identifierTextField)

--- a/AppReceiptValidator/AppReceiptValidator Tests Shared/AppReceiptValidationInAppPurchaseTests.swift
+++ b/AppReceiptValidator/AppReceiptValidator Tests Shared/AppReceiptValidationInAppPurchaseTests.swift
@@ -54,7 +54,7 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
             expirationDate: nil,
             inAppPurchaseReceipts: [
                 InAppPurchaseReceipt(
-                    quantity: nil,
+                    quantity: 1,
                     productIdentifier: "consumable",
                     transactionIdentifier: "1000000166865231",
                     originalTransactionIdentifier: "1000000166865231",
@@ -62,10 +62,10 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-07T20:37:55Z"),
                     subscriptionExpirationDate: nil,
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 0
                 ),
                 InAppPurchaseReceipt(
-                    quantity: nil,
+                    quantity: 1,
                     productIdentifier: "monthly",
                     transactionIdentifier: "1000000166965150",
                     originalTransactionIdentifier: "1000000166965150",
@@ -73,10 +73,10 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-10T06:49:33Z"),
                     subscriptionExpirationDate: Date.demoDate(string: "2015-08-10T06:54:32Z"),
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 1000000030274153
                 ),
-                InAppPurchaseReceipt( // restores
-                    quantity: nil,
+                InAppPurchaseReceipt(
+                    quantity: 1,
                     productIdentifier: "monthly",
                     transactionIdentifier: "1000000166965327",
                     originalTransactionIdentifier: "1000000166965150",
@@ -84,10 +84,10 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-10T06:53:18Z"),
                     subscriptionExpirationDate: Date.demoDate(string: "2015-08-10T06:59:32Z"),
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 1000000030274154
                 ),
                 InAppPurchaseReceipt(
-                    quantity: nil,
+                    quantity: 1,
                     productIdentifier: "monthly",
                     transactionIdentifier: "1000000166965895",
                     originalTransactionIdentifier: "1000000166965150",
@@ -95,10 +95,10 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-10T06:57:34Z"),
                     subscriptionExpirationDate: Date.demoDate(string: "2015-08-10T07:04:32Z"),
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 1000000030274165
                 ),
                 InAppPurchaseReceipt(
-                    quantity: nil,
+                    quantity: 1,
                     productIdentifier: "monthly",
                     transactionIdentifier: "1000000166967152",
                     originalTransactionIdentifier: "1000000166965150",
@@ -106,10 +106,10 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-10T07:02:33Z"),
                     subscriptionExpirationDate: Date.demoDate(string: "2015-08-10T07:09:32Z"),
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 1000000030274192
                 ),
                 InAppPurchaseReceipt(
-                    quantity: nil,
+                    quantity: 1,
                     productIdentifier: "monthly",
                     transactionIdentifier: "1000000166967484",
                     originalTransactionIdentifier: "1000000166965150",
@@ -117,10 +117,10 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-10T07:08:30Z"),
                     subscriptionExpirationDate: Date.demoDate(string: "2015-08-10T07:14:32Z"),
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 1000000030274219
                 ),
                 InAppPurchaseReceipt(
-                    quantity: nil,
+                    quantity: 1,
                     productIdentifier: "monthly",
                     transactionIdentifier: "1000000166967782",
                     originalTransactionIdentifier: "1000000166965150",
@@ -128,8 +128,9 @@ class AppReceiptValidationInAppPurchaseTests: XCTestCase {
                     originalPurchaseDate: Date.demoDate(string: "2015-08-10T07:12:34Z"),
                     subscriptionExpirationDate: Date.demoDate(string: "2015-08-10T07:19:32Z"),
                     cancellationDate: nil,
-                    webOrderLineItemId: nil
+                    webOrderLineItemId: 1000000030274249
                 )
-            ])
+            ]
+        )
     }
 }

--- a/AppReceiptValidator/AppReceiptValidator Tests Shared/Tools/KnownOrUnknown.swift
+++ b/AppReceiptValidator/AppReceiptValidator Tests Shared/Tools/KnownOrUnknown.swift
@@ -47,8 +47,8 @@ extension KnownOrUnknown: RawRepresentable {
 
 extension KnownOrUnknown: Hashable {
 
-    public var hashValue: Int {
-        return self.rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue.hashValue)
     }
 
     public static func == (lhs: KnownOrUnknown<Known>, rhs: KnownOrUnknown<Known>) -> Bool {

--- a/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
+++ b/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
@@ -1213,7 +1213,7 @@
 				TargetAttributes = {
 					D19095801F6000A40095729B = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
@@ -1223,7 +1223,7 @@
 					};
 					D19095911F6000A40095729B = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					D19095A81F6001800095729B = {
@@ -1238,7 +1238,7 @@
 					};
 					D1D6F4C11F5D687400E86FE1 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					D1D6F4E31F5D691400E86FE1 = {
@@ -1529,7 +1529,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1547,7 +1547,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1565,7 +1565,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideasoncanvas.AppReceiptValidator-Demo-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1583,7 +1583,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideasoncanvas.AppReceiptValidator-Demo-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1819,7 +1819,7 @@
 				PRODUCT_NAME = AppReceiptValidator;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1851,7 +1851,7 @@
 				PRODUCT_NAME = AppReceiptValidator;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
+++ b/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
@@ -1228,12 +1228,12 @@
 					};
 					D19095A81F6001800095729B = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					D1D6F4B41F5D684C00E86FE1 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					D1D6F4C11F5D687400E86FE1 = {
@@ -1243,7 +1243,7 @@
 					};
 					D1D6F4E31F5D691400E86FE1 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1596,7 +1596,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideasoncanvas.AppReceiptValidator-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1610,7 +1610,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideasoncanvas.AppReceiptValidator-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1755,7 +1755,7 @@
 				PRODUCT_NAME = AppReceiptValidator;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1786,7 +1786,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideasoncanvas.AppReceiptValidator;
 				PRODUCT_NAME = AppReceiptValidator;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1869,7 +1869,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideasoncanvas.AppReceiptValidator.Demo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1885,7 +1885,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideasoncanvas.AppReceiptValidator.Demo-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator+Parameters.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator+Parameters.swift
@@ -12,7 +12,7 @@ public extension AppReceiptValidator {
 
     /// Describes how to validate a receipt, and how/where to obtain the dependencies (receipt, deviceIdentifier, apple root certificate)
     /// Use .default to initialize the standard parameters. By default, no `propertyValidations` are active.
-    public struct Parameters {
+    struct Parameters {
 
         // MARK: - Properties
 
@@ -85,7 +85,7 @@ public extension AppReceiptValidator.Parameters {
     ///
     /// - currentDevice: Obtains it from the system location: MAC Address on macOS, deviceIdentifierForVendor on iOS
     /// - data: Specific Data to use
-    public enum DeviceIdentifier {
+    enum DeviceIdentifier {
 
         case currentDevice
         case data(Data)

--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
@@ -245,6 +245,7 @@ private extension AppReceiptValidator {
         return (receipt: receipt, unofficialReceipt: unofficialReceipt)
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func parseInAppPurchaseReceipt(pointer: UnsafePointer<UInt8>, length: Int) throws -> InAppPurchaseReceipt {
         var inAppPurchaseReceipt = InAppPurchaseReceipt()
         try self.parseASN1Set(pointer: pointer, length: length) { attributeType, value in

--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
@@ -247,24 +247,25 @@ private extension AppReceiptValidator {
         var inAppPurchaseReceipt = InAppPurchaseReceipt()
         try self.parseASN1Set(pointer: pointer, length: length) { attributeType, value in
             guard let attribute = KnownInAppPurchaseAttribute(rawValue: attributeType) else { return }
+            guard let value = value.unwrapped else { return } // always unwrap set members
 
             switch attribute {
             case .quantity:
                 inAppPurchaseReceipt.quantity = value.intValue
             case .productIdentifier:
-                inAppPurchaseReceipt.productIdentifier = value.unwrappedStringValue
+                inAppPurchaseReceipt.productIdentifier = value.stringValue
             case .transactionIdentifier:
-                inAppPurchaseReceipt.transactionIdentifier = value.unwrappedStringValue
+                inAppPurchaseReceipt.transactionIdentifier = value.stringValue
             case .originalTransactionIdentifier:
-                inAppPurchaseReceipt.originalTransactionIdentifier = value.unwrappedStringValue
+                inAppPurchaseReceipt.originalTransactionIdentifier = value.stringValue
             case .purchaseDate:
-                inAppPurchaseReceipt.purchaseDate = value.unwrappedDateValue
+                inAppPurchaseReceipt.purchaseDate = value.dateValue
             case .originalPurchaseDate:
-                inAppPurchaseReceipt.originalPurchaseDate = value.unwrappedDateValue
+                inAppPurchaseReceipt.originalPurchaseDate = value.dateValue
             case .subscriptionExpirationDate:
-                inAppPurchaseReceipt.subscriptionExpirationDate = value.unwrappedDateValue
+                inAppPurchaseReceipt.subscriptionExpirationDate = value.dateValue
             case .cancellationDate:
-                inAppPurchaseReceipt.cancellationDate = value.unwrappedDateValue
+                inAppPurchaseReceipt.cancellationDate = value.dateValue
             case .webOrderLineItemId:
                 inAppPurchaseReceipt.webOrderLineItemId = value.intValue
             }

--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
@@ -117,15 +117,17 @@ private extension AppReceiptValidator {
         var sha1Context = SHA_CTX()
 
         SHA1_Init(&sha1Context)
-
-        deviceIdentifierData.withUnsafeBytes { pointer -> Void in
-            SHA1_Update(&sha1Context, pointer, deviceIdentifierData.count)
+        deviceIdentifierData.withUnsafeBytes { poi -> Void in
+            print(poi)
         }
-        receiptOpaqueValueData.withUnsafeBytes { pointer -> Void in
-            SHA1_Update(&sha1Context, pointer, receiptOpaqueValueData.count)
+        _ = deviceIdentifierData.withUnsafeBytes { pointer -> Void in
+            SHA1_Update(&sha1Context, pointer.baseAddress, deviceIdentifierData.count)
         }
-        receiptBundleIdData.withUnsafeBytes { pointer -> Void in
-            SHA1_Update(&sha1Context, pointer, receiptBundleIdData.count)
+        _ = receiptOpaqueValueData.withUnsafeBytes { pointer -> Void in
+            SHA1_Update(&sha1Context, pointer.baseAddress, receiptOpaqueValueData.count)
+        }
+        _ = receiptBundleIdData.withUnsafeBytes { pointer -> Void in
+            SHA1_Update(&sha1Context, pointer.baseAddress, receiptBundleIdData.count)
         }
         SHA1_Final(&computedHash, &sha1Context)
 

--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
@@ -9,6 +9,8 @@
 import AppReceiptValidator.OpenSSL
 import Foundation
 
+// swiftlint:disable file_length
+
 /// Apple guide: https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Introduction.html
 ///
 /// Original inspiration for the Code: https://github.com/andrewcbancroft/SwiftyLocalReceiptValidator/blob/master/ReceiptValidator.swift

--- a/AppReceiptValidator/AppReceiptValidator/DeviceIdentifier+installedDeviceIdentifier_macOS.swift
+++ b/AppReceiptValidator/AppReceiptValidator/DeviceIdentifier+installedDeviceIdentifier_macOS.swift
@@ -53,6 +53,6 @@ extension AppReceiptValidator.Parameters.DeviceIdentifier {
             .map { String(format: "%02x", $0) }
             .joined(separator: ":")
 
-        return (data: Data(bytes: address), addressString: addressString)
+        return (data: Data(address), addressString: addressString)
     }
 }

--- a/AppReceiptValidator/AppReceiptValidator/OpenSSL/ASN1Helpers.swift
+++ b/AppReceiptValidator/AppReceiptValidator/OpenSSL/ASN1Helpers.swift
@@ -9,6 +9,8 @@
 import AppReceiptValidator.OpenSSL
 import Foundation
 
+// A resource for ASN1 can be https://www.oss.com/asn1/resources/reference/asn1-reference-card.html
+
 /// An ASN1 Sequence Object. Of interest are the attributeType and the valueObject.
 /// The attributeType determines how to interpret the valueObject.
 ///
@@ -116,7 +118,11 @@ extension ASN1Object {
 
 extension ASN1Object {
 
+    /// Unwraps an OCTET_STRING, which is a binary container, that can contain another ASN1Object.
+    /// This is the case when we are looking at an entry in an ASN1Set
     var unwrapped: ASN1Object? {
+        guard self.type == V_ASN1_OCTET_STRING else { return nil }
+
         guard let endPointer = valuePointer?.advanced(by: length) else { return nil }
 
         var innerPointer = valuePointer
@@ -154,6 +160,10 @@ extension ASN1Object {
 // MARK: - IntValue
 
 extension ASN1Object {
+
+    var unwrappedIntValue: Int? {
+        return self.unwrapped?.intValue
+    }
 
     var intValue: Int? {
         guard self.type == V_ASN1_INTEGER else { return nil }

--- a/AppReceiptValidator/AppReceiptValidator/OpenSSL/ASN1Helpers.swift
+++ b/AppReceiptValidator/AppReceiptValidator/OpenSSL/ASN1Helpers.swift
@@ -161,11 +161,11 @@ extension ASN1Object {
 
 extension ASN1Object {
 
-    var unwrappedIntValue: Int? {
+    var unwrappedIntValue: Int64? {
         return self.unwrapped?.intValue
     }
 
-    var intValue: Int? {
+    var intValue: Int64? {
         guard self.type == V_ASN1_INTEGER else { return nil }
 
         var pointer = self.valuePointer
@@ -173,11 +173,11 @@ extension ASN1Object {
         defer {
             ASN1_INTEGER_free(integer)
         }
-        let result = ASN1_INTEGER_get(integer)
+        let result = Int64(ASN1_INTEGER_get(integer))
         return result
     }
 
-    func intValue(byAdvancingPointer pointer: inout UnsafePointer<UInt8>?, length: Int? = nil) -> Int? {
+    func intValue(byAdvancingPointer pointer: inout UnsafePointer<UInt8>?, length: Int? = nil) -> Int64? {
         let length = length ?? self.length
         pointer = pointer?.advanced(by: length)
         guard let intValue = self.intValue else { return nil }

--- a/AppReceiptValidator/AppReceiptValidator/OpenSSL/OpenSSLWrappers.swift
+++ b/AppReceiptValidator/AppReceiptValidator/OpenSSL/OpenSSLWrappers.swift
@@ -14,8 +14,8 @@ final class BIOWrapper {
     let bio = BIO_new(BIO_s_mem())
 
     init(data: Data) {
-        data.withUnsafeBytes { pointer -> Void in
-            BIO_write(self.bio, pointer, Int32(data.count))
+        _ = data.withUnsafeBytes { pointer in
+            BIO_write(self.bio, pointer.baseAddress, Int32(data.count))
         }
     }
 

--- a/AppReceiptValidator/AppReceiptValidator/Receipt.swift
+++ b/AppReceiptValidator/AppReceiptValidator/Receipt.swift
@@ -55,6 +55,7 @@ public struct Receipt: Equatable {
     ///         The in-app purchase receipt for a non-consumable product, auto-renewable subscription, non-renewing subscription, or free subscription remains in the receipt indefinitely.
     public internal(set) var inAppPurchaseReceipts: [InAppPurchaseReceipt] = []
 
+    /// For documentation of parameters, have a look at the documented properties of `Receipt`
     public init(bundleIdentifier: String?, bundleIdData: Data?, appVersion: String?, opaqueValue: Data?, sha1Hash: Data?, originalAppVersion: String?, receiptCreationDate: Date?, expirationDate: Date?, inAppPurchaseReceipts: [InAppPurchaseReceipt]) {
         self.bundleIdentifier = bundleIdentifier
         self.bundleIdData = bundleIdData
@@ -67,12 +68,35 @@ public struct Receipt: Equatable {
         self.inAppPurchaseReceipts = inAppPurchaseReceipts
     }
 
+    /// Convenience initializer with stringified parameters for `Date` and `Data` type parameters.
+    /// When logging a `Receipt`'s (`CustomStringConvertible`) description, you can use that as swift source code calling this initializer,
+    /// which can simplify creating tests.
+    ///
+    /// For documentation of parameters, have a look at the documented properties of `Receipt`.
+    ///
+    /// - Note: Dates must be formatted as "2017-01-01T12:00:00Z", otherwise will be assigned `nil`.
+    /// Data must be formatted as Base64, otherwise will be assigned `nil`.
+    /// Correct formatting will be asserted in DEBUG builds.
+    public init(bundleIdentifier: String, bundleIdData: String, appVersion: String, opaqueValue: String, sha1Hash: String, originalAppVersion: String, receiptCreationDate: String, expirationDate: String?, inAppPurchaseReceipts: [InAppPurchaseReceipt]) {
+        self.init(bundleIdentifier: bundleIdentifier,
+                  bundleIdData: parseBase64(string: bundleIdData),
+                  appVersion: appVersion,
+                  opaqueValue: parseBase64(string: opaqueValue),
+                  sha1Hash: parseBase64(string: sha1Hash),
+                  originalAppVersion: originalAppVersion,
+                  receiptCreationDate: parseDate(string: receiptCreationDate),
+                  expirationDate: expirationDate.flatMap { parseDate(string: $0) },
+                  inAppPurchaseReceipts: inAppPurchaseReceipts)
+    }
+
     public init() {}
 }
 
 // MARK: - CustomStringConvertible
 
 extension Receipt: CustomStringConvertible, CustomDebugStringConvertible {
+
+    // This description is carefully matched to match the stringy convenience initializer of `Receipt`
 
     public var description: String {
         let formatter = StringFormatter()
@@ -101,7 +125,7 @@ extension Receipt: CustomStringConvertible, CustomDebugStringConvertible {
 ///
 /// Documentation was obtained from: https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html
 ///
-/// The following fields are part of JSON communication but not part of the parsed version (matched Sept 2017):
+/// The following fields are part of JSON communication but not part of the parsed version (matched May 2019):
 /// - Subscription Expiration Intent
 /// - Subscription Retry Flag
 /// - Subscription Trial Period
@@ -169,7 +193,7 @@ public struct InAppPurchaseReceipt: Equatable {
     /// This value is a unique ID that identifies purchase events across devices, including subscription renewal purchase events.
     public internal(set) var webOrderLineItemId: Int?
 
-    /// For documentation see InAppPurchaseReceipt itself.
+    /// For documentation of parameters, have a look at the documented properties of `InAppPurchaseReceipt`.
     public init(quantity: Int?, productIdentifier: String?, transactionIdentifier: String?, originalTransactionIdentifier: String?, purchaseDate: Date?, originalPurchaseDate: Date?, subscriptionExpirationDate: Date?, cancellationDate: Date?, webOrderLineItemId: Int?) {
         self.quantity = quantity
         self.productIdentifier = productIdentifier
@@ -182,12 +206,35 @@ public struct InAppPurchaseReceipt: Equatable {
         self.webOrderLineItemId = webOrderLineItemId
     }
 
+    /// Convenience initializer with stringified parameters for `Date` and `Data` type parameters.
+    /// When logging a `Receipt`'s (`CustomStringConvertible`) description, you can use that as swift source code calling this initializer,
+    /// which can simplify creating tests.
+    ///
+    /// For documentation of parameters, have a look at the documented properties of `InAppPurchaseReceipt`.
+    ///
+    /// - Note: Dates must be formatted as "2017-01-01T12:00:00Z", otherwise will be assigned `nil`.
+    /// Data must be formatted as Base64, otherwise will be assigned `nil`.
+    /// Correct formatting will be asserted in DEBUG builds.
+    public init(quantity: Int?, productIdentifier: String, transactionIdentifier: String, originalTransactionIdentifier: String, purchaseDate: String, originalPurchaseDate: String, subscriptionExpirationDate: String?, cancellationDate: String?, webOrderLineItemId: Int?) {
+        self.init(quantity: quantity,
+                  productIdentifier: productIdentifier,
+                  transactionIdentifier: transactionIdentifier,
+                  originalTransactionIdentifier: originalTransactionIdentifier,
+                  purchaseDate: parseDate(string: purchaseDate),
+                  originalPurchaseDate: parseDate(string: originalPurchaseDate),
+                  subscriptionExpirationDate: subscriptionExpirationDate.flatMap { parseDate(string: $0) },
+                  cancellationDate: cancellationDate.flatMap { parseDate(string: $0) },
+                  webOrderLineItemId: webOrderLineItemId)
+    }
+
     public init() {}
 }
 
 // MARK: - CustomStringConvertible
 
 extension InAppPurchaseReceipt: CustomStringConvertible, CustomDebugStringConvertible {
+
+    // This description is carefully matched to match the stringy convenience initializer of `InAppPurchaseReceipt`
 
     public var description: String {
         let formatter = StringFormatter()
@@ -258,4 +305,23 @@ private struct StringFormatter {
     func quoted(_ string: String) -> String {
         return "\"" + string + "\""
     }
+}
+
+private func parseBase64(string: String) -> Data? {
+    guard let data = Data(base64Encoded: string) else {
+        assertionFailure("Data could not be parsed from string '\(string)', make sure it is non-empty nad base64 encoded.")
+        return nil
+    }
+
+    return data
+}
+
+// Parses a string of type "2017-01-01T12:00:00Z"
+private func parseDate(string: String) -> Date? {
+    guard let date = AppReceiptValidator.asn1DateFormatter.date(from: string) else {
+        assertionFailure("Date could not be parsed from string '\(string)', make sure it has a correct format, example  `2017-01-01T12:00:00Z`")
+        return nil
+    }
+
+    return date
 }

--- a/AppReceiptValidator/AppReceiptValidator/Receipt.swift
+++ b/AppReceiptValidator/AppReceiptValidator/Receipt.swift
@@ -241,16 +241,21 @@ private struct StringFormatter {
     func format(_ data: Data?) -> String {
         guard let data = data else { return fallback }
 
-        return data.base64EncodedString()
+        return quoted(data.base64EncodedString())
     }
 
     func format(_ date: Date?) -> String {
         guard let date = date else { return fallback }
 
-        return AppReceiptValidator.asn1DateFormatter.string(from: date)
+        return quoted(AppReceiptValidator.asn1DateFormatter.string(from: date))
     }
 
     func format(_ string: String?) -> String {
-        return string ?? fallback
+        return string.map(quoted) ?? fallback
+    }
+
+    /// Surrounds a string with quotes "…"
+    func quoted(_ string: String) -> String {
+        return "\"" + string + "\""
     }
 }

--- a/AppReceiptValidator/AppReceiptValidator/Receipt.swift
+++ b/AppReceiptValidator/AppReceiptValidator/Receipt.swift
@@ -139,7 +139,7 @@ public struct InAppPurchaseReceipt: Equatable {
 
     /// The number of items purchased. ASN.1 Field Type 1701.
     /// This value corresponds to the quantity property of the `SKPayment` object stored in the transaction’s payment property.
-    public internal(set) var quantity: Int?
+    public internal(set) var quantity: Int64?
 
     /// The product identifier of the item that was purchased. ASN.1 Field Type 1702.
     /// This value corresponds to the `productIdentifier` property of the `SKPayment` object stored in the transaction’s `payment` property.
@@ -191,10 +191,10 @@ public struct InAppPurchaseReceipt: Equatable {
 
     /// The primary key for identifying subscription purchases. ASN.1 Field Type 1711.
     /// This value is a unique ID that identifies purchase events across devices, including subscription renewal purchase events.
-    public internal(set) var webOrderLineItemId: Int?
+    public internal(set) var webOrderLineItemId: Int64?
 
     /// For documentation of parameters, have a look at the documented properties of `InAppPurchaseReceipt`.
-    public init(quantity: Int?, productIdentifier: String?, transactionIdentifier: String?, originalTransactionIdentifier: String?, purchaseDate: Date?, originalPurchaseDate: Date?, subscriptionExpirationDate: Date?, cancellationDate: Date?, webOrderLineItemId: Int?) {
+    public init(quantity: Int64?, productIdentifier: String?, transactionIdentifier: String?, originalTransactionIdentifier: String?, purchaseDate: Date?, originalPurchaseDate: Date?, subscriptionExpirationDate: Date?, cancellationDate: Date?, webOrderLineItemId: Int64?) {
         self.quantity = quantity
         self.productIdentifier = productIdentifier
         self.transactionIdentifier = transactionIdentifier
@@ -215,7 +215,7 @@ public struct InAppPurchaseReceipt: Equatable {
     /// - Note: Dates must be formatted as "2017-01-01T12:00:00Z", otherwise will be assigned `nil`.
     /// Data must be formatted as Base64, otherwise will be assigned `nil`.
     /// Correct formatting will be asserted in DEBUG builds.
-    public init(quantity: Int?, productIdentifier: String, transactionIdentifier: String, originalTransactionIdentifier: String, purchaseDate: String, originalPurchaseDate: String, subscriptionExpirationDate: String?, cancellationDate: String?, webOrderLineItemId: Int?) {
+    public init(quantity: Int64?, productIdentifier: String, transactionIdentifier: String, originalTransactionIdentifier: String, purchaseDate: String, originalPurchaseDate: String, subscriptionExpirationDate: String?, cancellationDate: String?, webOrderLineItemId: Int64?) {
         self.init(quantity: quantity,
                   productIdentifier: productIdentifier,
                   transactionIdentifier: transactionIdentifier,
@@ -275,7 +275,7 @@ private struct StringFormatter {
         return pairs.map { self.format(key: $0, value: $1) }.joined(separator: ",\n")
     }
 
-    func format(_ int: Int?) -> String {
+    func format(_ int: Int64?) -> String {
         guard let int = int else { return fallback }
 
         return "\(int)"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 ![Platforms iOS, macOS](https://img.shields.io/badge/Platform-iOS%20|%20macOS-blue.svg "Platforms iOS, macOS")
-![Language Swift](https://img.shields.io/badge/Language-Swift%204.2-orange.svg "Swift 4.2")
+![Language Swift](https://img.shields.io/badge/Language-Swift%204.2-orange.svg "Swift 5.0")
 [![License Apache 2.0 + OpenSSL](https://img.shields.io/badge/License-Apache%202.0%20|%20OpenSSL%20-aaaaff.svg "License")](LICENSE)
 [![Build Status](https://travis-ci.org/IdeasOnCanvas/AppReceiptValidator.svg?branch=master)](https://travis-ci.org/IdeasOnCanvas/AppReceiptValidator)
 [![Twitter: @hannesoid](https://img.shields.io/badge/Twitter-@hannesoid-red.svg?style=flat)](https://twitter.com/hannesoid)


### PR DESCRIPTION
`quantity` and `webOrderLineItemID` were always parsed as `nil`

- This fixes `quantity` and `webOrderLineItemID` parsing, by correctly unwrapping int entries in ASN1 parsing
- Update for Xcode 10.2 and migrate to Swift 5
- Add stringy convenience initializers, and improve description to match them