### PR TITLE
Add dynamic data retriever as Receipt Origin

### DIFF
--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator+Parameters.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator+Parameters.swift
@@ -62,11 +62,14 @@ extension AppReceiptValidator.Parameters {
 
         case installedInMainBundle
         case data(Data)
+        case dynamic(() -> Data?)
 
         public func loadData() -> Data? {
             switch self {
             case .data(let data):
                 return data
+            case .dynamic(let maker):
+                return maker()
             case .installedInMainBundle:
                 guard let receiptUrl = Bundle.main.appStoreReceiptURL else { return nil }
                 guard (try? receiptUrl.checkResourceIsReachable()) ?? false else { return nil }

--- a/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
+++ b/AppReceiptValidator/AppReceiptValidator/AppReceiptValidator.swift
@@ -9,8 +9,6 @@
 import AppReceiptValidator.OpenSSL
 import Foundation
 
-// swiftlint:disable file_length
-
 /// Apple guide: https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Introduction.html
 ///
 /// Original inspiration for the Code: https://github.com/andrewcbancroft/SwiftyLocalReceiptValidator/blob/master/ReceiptValidator.swift


### PR DESCRIPTION
This is useful for setting up tests, where receipt origin comes from a shared place resolved by a block