### PR TITLE
Support Xcode 11

### DIFF
--- a/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
+++ b/AppReceiptValidator/AppReceiptValidator.xcodeproj/project.pbxproj
@@ -1754,6 +1754,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideasoncanvas.AppReceiptValidator;
 				PRODUCT_NAME = AppReceiptValidator;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1786,6 +1787,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideasoncanvas.AppReceiptValidator;
 				PRODUCT_NAME = AppReceiptValidator;
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
Xcode 11 doesn't compile for iOS, because it has Catalyst activated by default, and has issues with iOS OpenSSL not including a slice for it.

- Deactivate maccatalyst (as long as it’s not figured out how to compile)
- Prevents compilation in Xcode 10, because the project file format has changed

Questions:
- figure out how to get openssl into a catalyst supportive shape, related #55 and https://github.com/krzyzanowskim/OpenSSL/issues/60  / or can we reuse the openssl lib already compiled macos for use with catalyst somehow?
- use xcframework for bundling it all up?
- can packagemanager be used?

