### PR TITLE
Use tag to specify ASN1Decoder dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
         "state": {
           "branch": null,
           "revision": "6f36ef23becd7f9266ef6b026af4798996a1a8be",
-          "version": null
+          "version": "1.8.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,7 @@ let package = Package(
         .library(name: "AppReceiptValidator", type: .dynamic, targets: ["AppReceiptValidator"]),
     ],
     dependencies: [
-		// We currently can't use semantic versioning because the repo uses invalid version strings (e.g. "1.5" instead of "1.5.0")
-        .package(url: "https://github.com/IdeasOnCanvas/ASN1Decoder", .revision("6f36ef23becd7f9266ef6b026af4798996a1a8be")),
+        .package(url: "https://github.com/IdeasOnCanvas/ASN1Decoder", from: "1.8.1"),
         .package(url: "https://github.com/apple/swift-crypto", from: "1.1.0")
     ],
     targets: [


### PR DESCRIPTION
To avoid issues with other packages that depend on AppReceiptValidator, this pins the ASN1Decoder dependency to a specific tag, not a commit.

This is the error that could be observed (when running `swift test`):
```
Computing version for https://github.com/IdeasOnCanvas/AppReceiptValidator.git
error: Dependencies could not be resolved because root depends on 'AppReceiptValidator' 1.0.0..<2.0.0.
'AppReceiptValidator' >= 1.0.0 cannot be used because package 'appreceiptvalidator' is required using a stable-version but 'appreceiptvalidator' depends on an unstable-version package 'asn1decoder' and no versions of 'AppReceiptValidator' match the requirement 1.0.1..<2.0.0.
```