### PR TITLE
Fix parsing of provisioning type (unofficial receipt parts)

### DIFF
--- a/Sources/AppReceiptValidator/AppReceiptValidator.swift
+++ b/Sources/AppReceiptValidator/AppReceiptValidator.swift
@@ -212,7 +212,7 @@ private extension AppReceiptValidator {
               let items = receiptBlock.sub else { return .init(entries: []) }
 
         let entries: [UnofficialReceipt.Entry] = items.compactMap { item in
-            guard let fieldType = (item.sub(0)?.value as? Data)?.uint64Value,
+            guard let fieldType = (item.sub(0)?.value as? Data)?.uint64ValueOrZero, // provisioning fieldtype pops up here as empty Data, so we use uint64ValueOrZero
                   KnownReceiptAttribute(rawValue: fieldType) == nil else { return nil }
 
             let fieldValueString = item.sub(2)?.asString
@@ -397,4 +397,16 @@ extension X509PublicKey {
         }
     }
     #endif
+}
+
+// MARK: - Data + Unofficial Receipt FieldTypes
+
+private extension Data {
+
+    /// Decoded as by ASN1Decoder's Data.uint64Value extension, or as 0 if empty
+    var uint64ValueOrZero: UInt64? {
+        if self.isEmpty { return 0 }
+
+        return self.uint64Value
+    }
 }

--- a/Tests/AppReceiptValidatorTests/AppReceiptValidatorTests.swift
+++ b/Tests/AppReceiptValidatorTests/AppReceiptValidatorTests.swift
@@ -247,6 +247,27 @@ class AppReceiptValidatorTests: XCTestCase {
         XCTAssertEqual(receipt, expected)
     }
 
+    func testUnofficialProvisioningTypes() throws {
+        do {
+            guard let data = assertB64TestAsset(filename: "mindnode_ios_michaelsandbox_receipt1.b64") else { return }
+
+            let result = try receiptValidator.parseUnofficialReceipt(origin: .data(data))
+            XCTAssertEqual(result.unofficialReceipt.provisioningType, .known(value: .productionSandbox))
+        }
+        do {
+            guard let data = assertB64TestAsset(filename: "mindnode_ios_michaelsandbox_receipt2.b64") else { return }
+
+            let result = try receiptValidator.parseUnofficialReceipt(origin: .data(data))
+            XCTAssertEqual(result.unofficialReceipt.provisioningType, .known(value: .productionSandbox))
+        }
+        do {
+            guard let data = assertB64TestAsset(filename: "hannes_mac_mindnode_receipt.b64") else { return }
+
+            let result = try receiptValidator.parseUnofficialReceipt(origin: .data(data))
+            XCTAssertEqual(result.unofficialReceipt.provisioningType, .known(value: .production))
+        }
+    }
+
     func testMindNodeiOSSandBoxReceipt2ParsingAndValidation() {
         guard let data = assertB64TestAsset(filename: "mindnode_ios_michaelsandbox_receipt2.b64") else { return }
 


### PR DESCRIPTION
The provisioning type was no longer parsed, since we changed from OpenSSL to ASN1Decoder, this is fixed in this PR.