### PR TITLE
Make MAC address retrieval prioritize built-in interfaces over external ones

### DIFF
--- a/Sources/AppReceiptValidator/DeviceIdentifier+installedDeviceIdentifier_macOS.swift
+++ b/Sources/AppReceiptValidator/DeviceIdentifier+installedDeviceIdentifier_macOS.swift
@@ -22,39 +22,75 @@ extension AppReceiptValidator.Parameters.DeviceIdentifier {
     ///
     /// - Returns: The MAC Address as Data and String representation
     public static func getPrimaryNetworkMACAddress() -> (data: Data, addressString: String)? {
-        let matching = IOServiceMatching("IOEthernetInterface") as NSMutableDictionary
-        matching[kIOPropertyMatchKey] = ["IOPrimaryInterface": true]
-        var servicesIterator: io_iterator_t = 0
-        defer { IOObjectRelease(servicesIterator) }
-
-        guard IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &servicesIterator) == KERN_SUCCESS else { return nil }
+        guard let data = copyMACAddress() else { return nil }
 
         var address: [UInt8] = [0, 0, 0, 0, 0, 0]
-        var service = IOIteratorNext(servicesIterator)
+        data.copyBytes(to: &address, count: address.count)
 
-        while service != 0 {
-            var controllerService: io_object_t = 0
-
-            defer {
-                IOObjectRelease(service)
-                IOObjectRelease(controllerService)
-                service = IOIteratorNext(servicesIterator)
-            }
-
-            guard IORegistryEntryGetParentEntry(service, "IOService", &controllerService) == KERN_SUCCESS else { continue }
-
-            let ref = IORegistryEntryCreateCFProperty(controllerService, "IOMACAddress" as CFString, kCFAllocatorDefault, 0)
-
-            guard let data = ref?.takeRetainedValue() as? Data else { continue }
-
-            data.copyBytes(to: &address, count: address.count)
-        }
 
         let addressString = address
             .map { String(format: "%02x", $0) }
             .joined(separator: ":")
 
         return (data: Data(address), addressString: addressString)
+    }
+}
+
+private extension AppReceiptValidator.Parameters.DeviceIdentifier {
+
+    // Returns an object with a +1 retain count; the caller must release.
+    static func io_service(named name: String, wantBuiltIn: Bool) -> io_service_t? {
+        let default_port = kIOMasterPortDefault
+        var iterator = io_iterator_t()
+        defer {
+            if iterator != IO_OBJECT_NULL {
+                IOObjectRelease(iterator)
+            }
+        }
+
+        guard let matchingDict = IOBSDNameMatching(default_port, 0, name),
+              IOServiceGetMatchingServices(default_port,
+                                           matchingDict as CFDictionary,
+                                           &iterator) == KERN_SUCCESS,
+              iterator != IO_OBJECT_NULL
+        else {
+            return nil
+        }
+
+        var candidate = IOIteratorNext(iterator)
+        while candidate != IO_OBJECT_NULL {
+            if let cftype = IORegistryEntryCreateCFProperty(candidate,
+                                                            "IOBuiltin" as CFString,
+                                                            kCFAllocatorDefault,
+                                                            0) {
+                let isBuiltIn = cftype.takeRetainedValue() as! CFBoolean
+                if wantBuiltIn == CFBooleanGetValue(isBuiltIn) {
+                    return candidate
+                }
+            }
+
+            IOObjectRelease(candidate)
+            candidate = IOIteratorNext(iterator)
+        }
+
+        return nil
+    }
+
+    static func copyMACAddress() -> Data? {
+        // Prefer built-in network interfaces.
+        // For example, an external Ethernet adaptor could displace
+        // the built-in Wi-Fi as en0.
+        guard let service = io_service(named: "en0", wantBuiltIn: true)
+                ?? io_service(named: "en1", wantBuiltIn: true)
+                ?? io_service(named: "en0", wantBuiltIn: false)
+        else { return nil }
+        defer { IOObjectRelease(service) }
+
+        if let cftype = IORegistryEntrySearchCFProperty(service, kIOServicePlane, "IOMACAddress" as CFString, kCFAllocatorDefault, IOOptionBits(kIORegistryIterateRecursively | kIORegistryIterateParents)) {
+            return (cftype as! Data)
+        }
+
+        return nil
     }
 }
 #endif

--- a/Sources/AppReceiptValidator/DeviceIdentifier+installedDeviceIdentifier_macOS.swift
+++ b/Sources/AppReceiptValidator/DeviceIdentifier+installedDeviceIdentifier_macOS.swift
@@ -18,7 +18,7 @@ extension AppReceiptValidator.Parameters.DeviceIdentifier {
     }
 
     /// Finds the MAC Address of the primary network interface.
-    /// Original implementation https://gist.github.com/mminer/82975d3781e2f42fc644d7fbfbf4f905
+    /// Based on: https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device
     ///
     /// - Returns: The MAC Address as Data and String representation
     public static func getPrimaryNetworkMACAddress() -> (data: Data, addressString: String)? {


### PR DESCRIPTION
Changes the MAC address retrieval code to use a different fallback mechanism to be in-line with Apple's documentation: 
https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device