### PR TITLE
Make legacy-style primary MAC address retrieval available  

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IdeasOnCanvas/ASN1Decoder",
         "state": {
           "branch": null,
-          "revision": "6f36ef23becd7f9266ef6b026af4798996a1a8be",
-          "version": "1.8.1"
+          "revision": "1fa1e9c68c27cbed56e2a997605ae2e808cf4d98",
+          "version": "1.8.2"
         }
       },
       {


### PR DESCRIPTION
Related Issue #83

We have encountered at least one case where receipt validation failed on macOS for a user, but would have succeeded when using the primary MAC address retrieved the "old style" (before https://github.com/IdeasOnCanvas/AppReceiptValidator/pull/79).

While it would be best to improve the retrieval of the MAC address in a way that it always returns the one that the system also used to sign the receipt, we don't yet know in which cases what to adjust.

This PR adds a way to retrieve the MAC address the old style, giving us an option to see if it may be benefitial to use the old style as a fallback to give receipt validation a second chance in those cases.

