### PR TITLE
Make swift to choose static and dynamic linking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         // .watchOS(.v6) watchOS doesn't have UIDevice.current so we can parse, but not validate hash, also, it cannot run XCTest
     ],
     products: [
-        .library(name: "AppReceiptValidator", type: .dynamic, targets: ["AppReceiptValidator"]),
+        .library(name: "AppReceiptValidator", targets: ["AppReceiptValidator"]),
     ],
     dependencies: [
         .package(url: "https://github.com/IdeasOnCanvas/ASN1Decoder", from: "1.8.2"),


### PR DESCRIPTION
According to document, it is recommended to not to set library type.

```
    /// - Parameters:
    ///   - name: The name of the library product.
    ///   - type: The optional type of the library that's used to determine how to
    ///     link to the library. Leave this parameter so
    ///     Swift Package Manager can choose between static or dynamic linking (recommended). If you
    ///     don't support both linkage types, use
    ///     ``Product/Library/LibraryType/static`` or
    ///     ``Product/Library/LibraryType/dynamic`` for this parameter
```

ref #81