### PR TITLE
Don't force library dynamic, add dynamic alternative

### DIFF
--- a/Example/AppReceiptValidator.xcodeproj/project.pbxproj
+++ b/Example/AppReceiptValidator.xcodeproj/project.pbxproj
@@ -8,9 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		80AB3E2F276CA8E100C4AB61 /* AppReceiptValidator in Frameworks */ = {isa = PBXBuildFile; productRef = 80AB3E2E276CA8E100C4AB61 /* AppReceiptValidator */; };
-		80AB3E30276CA8E100C4AB61 /* AppReceiptValidator in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 80AB3E2E276CA8E100C4AB61 /* AppReceiptValidator */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		80AB3E32276CA8E500C4AB61 /* AppReceiptValidator in Frameworks */ = {isa = PBXBuildFile; productRef = 80AB3E31276CA8E500C4AB61 /* AppReceiptValidator */; };
-		80AB3E33276CA8E500C4AB61 /* AppReceiptValidator in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 80AB3E31276CA8E500C4AB61 /* AppReceiptValidator */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D13E5B7D20331B9B001880F0 /* DropAcceptingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13E5B7C20331B9B001880F0 /* DropAcceptingTextView.swift */; };
 		D19095841F6000A40095729B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19095831F6000A40095729B /* AppDelegate.swift */; };
 		D19095861F6000A40095729B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19095851F6000A40095729B /* ViewController.swift */; };
@@ -30,7 +28,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				80AB3E33276CA8E500C4AB61 /* AppReceiptValidator in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -41,7 +38,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				80AB3E30276CA8E100C4AB61 /* AppReceiptValidator in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/AppReceiptValidator.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/AppReceiptValidator.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IdeasOnCanvas/ASN1Decoder",
         "state": {
           "branch": null,
-          "revision": "6f36ef23becd7f9266ef6b026af4798996a1a8be",
-          "version": "1.8.1"
+          "revision": "1fa1e9c68c27cbed56e2a997605ae2e808cf4d98",
+          "version": "1.8.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
         // .watchOS(.v6) watchOS doesn't have UIDevice.current so we can parse, but not validate hash, also, it cannot run XCTest
     ],
     products: [
-        .library(name: "AppReceiptValidator", type: .dynamic, targets: ["AppReceiptValidator"]),
+        .library(name: "AppReceiptValidator", targets: ["AppReceiptValidator"]),
+        .library(name: "AppReceiptValidatorDynamic", type: .dynamic, targets: ["AppReceiptValidator"]),
     ],
     dependencies: [
         .package(url: "https://github.com/IdeasOnCanvas/ASN1Decoder", from: "1.8.2"),


### PR DESCRIPTION
Fixes #81

- make the library not explicitly dynamic (lets xcode / spm choose)
- adds a second library that is explicitly dynamic
<img width="805" alt="Bildschirmfoto 2022-09-12 um 14 03 00" src="https://user-images.githubusercontent.com/1856655/189648459-27539775-121c-48b4-bb21-f1d9623e86a1.png">
