### PR TITLE
Update Swift Crypto dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "ASN1Decoder",
-        "repositoryURL": "https://github.com/IdeasOnCanvas/ASN1Decoder",
-        "state": {
-          "branch": null,
-          "revision": "1fa1e9c68c27cbed56e2a997605ae2e808cf4d98",
-          "version": "1.8.2"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto",
-        "state": {
-          "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
-        }
+  "pins" : [
+    {
+      "identity" : "asn1decoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/IdeasOnCanvas/ASN1Decoder",
+      "state" : {
+        "revision" : "1fa1e9c68c27cbed56e2a997605ae2e808cf4d98",
+        "version" : "1.8.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "60f13f60c4d093691934dc6cfdf5f508ada1f894",
+        "version" : "2.6.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IdeasOnCanvas/ASN1Decoder", from: "1.8.2"),
-        .package(url: "https://github.com/apple/swift-crypto", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-crypto", "2.0.0" ..< "3.0.0")
     ],
     targets: [
         .target(name: "AppReceiptValidator",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IdeasOnCanvas/ASN1Decoder", from: "1.8.2"),
-        .package(url: "https://github.com/apple/swift-crypto", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-crypto", "2.0.0" ..< "3.0.0")
     ],
     targets: [
         .target(name: "AppReceiptValidator",


### PR DESCRIPTION
- Update Swift Crypto to > 2.x
- Update SHA1 code to use SwiftCrypto instead of BoringSSL